### PR TITLE
Config file appropriately handles list of creds

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -15,8 +15,10 @@ var (
 	CredLists        []CredData
 )
 
-func getCreds(teamID uint, credList string, checkName string) (string, string) {
+func getCreds(teamID uint, credLists []string, checkName string) (string, string) {
 	var usernameList CredData
+	rand.Seed(time.Now().UnixNano())
+	credList := credLists[rand.Intn(len(credLists))]
 	if credList != "" {
 		found := false
 		for _, l := range CredLists {
@@ -69,7 +71,7 @@ type checkBase struct {
 	Name      string // Name is the box name plus the service (ex. lunar-dns)
 	Display   string // Display is the name of the service (ex. dns)
 	IP        string
-	CredList  string
+	CredLists []string
 	Port      int
 	Anonymous bool
 }

--- a/checks/ftp.go
+++ b/checks/ftp.go
@@ -36,7 +36,7 @@ func (c Ftp) Run(teamID uint, boxIp string, res chan Result) {
 		username = "anonymous"
 		password = "anonymous"
 	} else {
-		username, password = getCreds(teamID, c.CredList, c.Name)
+		username, password = getCreds(teamID, c.CredLists, c.Name)
 	}
 	err = conn.Login(username, password)
 	if err != nil {

--- a/checks/imap.go
+++ b/checks/imap.go
@@ -40,7 +40,7 @@ func (c Imap) Run(teamID uint, boxIp string, res chan Result) {
 	defer cl.Close()
 
 	if !c.Anonymous {
-		username, password := getCreds(teamID, c.CredList, c.Name)
+		username, password := getCreds(teamID, c.CredLists, c.Name)
 		// Set timeout for commands
 		cl.Timeout = GlobalTimeout
 

--- a/checks/ldap.go
+++ b/checks/ldap.go
@@ -17,7 +17,7 @@ func (c Ldap) Run(teamID uint, boxIp string, res chan Result) {
 	// Set timeout
 	ldap.DefaultTimeout = GlobalTimeout
 
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 	scheme := "ldap"
 	if c.Encrypted {
 		scheme = "ldaps"

--- a/checks/smb.go
+++ b/checks/smb.go
@@ -26,7 +26,7 @@ func (c Smb) Run(teamID uint, boxIp string, res chan Result) {
 	// create smb object outside of if statement scope
 
 	// Authenticated SMB
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 
 	conn, err := net.Dial("tcp", boxIp+":"+strconv.Itoa(c.Port))
 	if err != nil {

--- a/checks/smtp.go
+++ b/checks/smtp.go
@@ -34,7 +34,7 @@ func (c Smtp) Run(teamID uint, boxIp string, res chan Result) {
 
 	// ***********************************************
 	// Set up custom auth for bypassing net/smtp protections
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 	auth := unencryptedAuth{smtp.PlainAuth("", username, password, boxIp)}
 	// ***********************************************
 

--- a/checks/sql.go
+++ b/checks/sql.go
@@ -27,7 +27,7 @@ type queryData struct {
 }
 
 func (c Sql) Run(teamID uint, boxIp string, res chan Result) {
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 
 	// Run query
 	q := c.Query[rand.Intn(len(c.Query))]

--- a/checks/ssh.go
+++ b/checks/ssh.go
@@ -27,7 +27,7 @@ type commandData struct {
 
 func (c Ssh) Run(teamID uint, boxIp string, res chan Result) {
 	// Create client config
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 	config := &ssh.ClientConfig{
 		User:            username,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),

--- a/checks/vnc.go
+++ b/checks/vnc.go
@@ -14,7 +14,7 @@ type Vnc struct {
 
 func (c Vnc) Run(teamID uint, boxIp string, res chan Result) {
 	// Configure the vnc client
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 	config := vnc.ClientConfig{
 		Auth: []vnc.ClientAuth{
 			&vnc.PasswordAuth{Password: password},

--- a/checks/winrm.go
+++ b/checks/winrm.go
@@ -25,7 +25,7 @@ type winCommandData struct {
 }
 
 func (c WinRM) Run(teamID uint, boxIp string, res chan Result) {
-	username, password := getCreds(teamID, c.CredList, c.Name)
+	username, password := getCreds(teamID, c.CredLists, c.Name)
 	params := *winrm.DefaultParameters
 
 	// Run bad attempts if specified

--- a/config.go
+++ b/config.go
@@ -284,7 +284,7 @@ func checkConfig(conf *config) error {
 				if ck.Name == "" {
 					ck.Name = b.Name + "-" + ck.Display
 				}
-				if ck.CredList == "" {
+				if len(ck.CredLists) < 1 {
 					ck.Anonymous = true
 				}
 				conf.Box[i].CheckList[j] = ck
@@ -498,7 +498,7 @@ func checkConfig(conf *config) error {
 				if len(ck.Url) == 0 {
 					return errors.New("no urls specified for web check " + ck.Name)
 				}
-				if ck.CredList == "" {
+				if len(ck.CredLists) < 1 {
 					ck.Anonymous = true
 				}
 				if ck.Scheme == "" {


### PR DESCRIPTION
Services specified under each Box in dwayne.conf now use a TOML list of strings (instead of a single string) to define which cred lists to be chosen from. README documentation probably doesn't need to be changed, since this is the way it the example is implying creds should work (but previously wasn't).